### PR TITLE
Fix menu UI size and make tooltip readable

### DIFF
--- a/Assets/Scenes/ARFoundationMenu/Menu.unity
+++ b/Assets/Scenes/ARFoundationMenu/Menu.unity
@@ -1142,8 +1142,8 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 774532499}
-  - {fileID: 2094799243}
   - {fileID: 749209459}
+  - {fileID: 2094799243}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3280,12 +3280,12 @@ RectTransform:
   - {fileID: 1459382205}
   - {fileID: 1948233962}
   m_Father: {fileID: 346867440}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -3.5872803, y: -13}
-  m_SizeDelta: {x: 1100, y: 900}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -61.6}
+  m_SizeDelta: {x: 0, y: -123.27222}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &749209460
 MonoBehaviour:
@@ -3300,7 +3300,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Content: {fileID: 1413559114}
-  m_Horizontal: 1
+  m_Horizontal: 0
   m_Vertical: 1
   m_MovementType: 1
   m_Elasticity: 0.1
@@ -3679,8 +3679,6 @@ MonoBehaviour:
   m_HumanSegmentationMenu: {fileID: 1468820548}
   m_PlaneDetectionMenu: {fileID: 881169046}
   m_MeshingMenu: {fileID: 2008080040}
-  m_SampleUX: {fileID: 0}
-  m_CheckSupport: {fileID: 0}
 --- !u!4 &774532499
 Transform:
   m_ObjectHideFlags: 0
@@ -7459,7 +7457,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000015258789, y: 0.00007243082}
+  m_AnchoredPosition: {x: 0.000015258789, y: -0.0002787175}
   m_SizeDelta: {x: 0, y: 1100}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &1416737520
@@ -7756,7 +7754,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1141134466}
   m_HandleRect: {fileID: 1141134465}
   m_Direction: 0
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -9929,7 +9927,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1130901185}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.80272734
+  m_Size: 0.9999984
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -10409,7 +10407,7 @@ RectTransform:
   - {fileID: 1742233075}
   - {fileID: 1536440841}
   m_Father: {fileID: 346867440}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}

--- a/Assets/XR/Loaders/AR Simulation Loader.asset
+++ b/Assets/XR/Loaders/AR Simulation Loader.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0a81a8e4c502874bba85236a26f338c, type: 3}
+  m_Name: AR Simulation Loader
+  m_EditorClassIdentifier: 

--- a/Assets/XR/Loaders/AR Simulation Loader.asset.meta
+++ b/Assets/XR/Loaders/AR Simulation Loader.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b425e0d414deb5241aa4dce1664f2656
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/Settings/AR Simulation Loader Settings.asset
+++ b/Assets/XR/Settings/AR Simulation Loader Settings.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4131c50fb82c3f844a2b9846971716b1, type: 3}
+  m_Name: AR Simulation Loader Settings
+  m_EditorClassIdentifier: 
+  m_firstInstallation: 0
+  m_StartAndStopSubsystems: 1
+  m_allowAddXRLoader: 1
+  m_allowAutoSceneSetup: 1
+  m_allowAutoPlane: 1
+  m_allowAutoPointCloud: 1
+  m_allowAutoAnchor: 1
+  m_allowAutoTrackedImage: 1
+  m_allowAutoSetupLogging: 0

--- a/Assets/XR/Settings/AR Simulation Loader Settings.asset.meta
+++ b/Assets/XR/Settings/AR Simulation Loader Settings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05439bf03262080498963c32373dade3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XR/XRGeneralSettings.asset
+++ b/Assets/XR/XRGeneralSettings.asset
@@ -29,7 +29,8 @@ MonoBehaviour:
   m_RequiresSettingsUpdate: 0
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
-  m_Loaders: []
+  m_Loaders:
+  - {fileID: 11400000, guid: b425e0d414deb5241aa4dce1664f2656, type: 2}
 --- !u!114 &-6122771651556369562
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,20 @@
 {
+  "scopedRegistries": [
+    {
+      "name": "needle",
+      "url": "https://packages.needle.tools",
+      "scopes": [
+        "com.needle"
+      ]
+    }
+  ],
   "dependencies": {
+    "com.needle.xr.arsimulation": "file:../../../../pfc-ar-desktop-plugin/package",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.analytics": "3.3.5",
     "com.unity.collab-proxy": "1.2.16",
+    "com.unity.device-simulator": "2.2.2-preview",
     "com.unity.ext.nunit": "1.0.0",
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.2.0",


### PR DESCRIPTION
Tooltip was behind the rest of the menu, and the menu wasn't set to stretch. This resulted in it being cut off on most phones and any landscape orientation.

Before: 
![20200618-015622_Unity](https://user-images.githubusercontent.com/2693840/84963043-9ec84080-b108-11ea-9706-3cc679941b0a.png)

After:
![image](https://user-images.githubusercontent.com/2693840/84963063-a7b91200-b108-11ea-9308-d5037edcd233.png)
