### PR TITLE
Fix menu UI size and make tooltip readable

### DIFF
--- a/Assets/Scenes/ARFoundationMenu/Menu.unity
+++ b/Assets/Scenes/ARFoundationMenu/Menu.unity
@@ -1142,8 +1142,8 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 774532499}
-  - {fileID: 2094799243}
   - {fileID: 749209459}
+  - {fileID: 2094799243}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3280,12 +3280,12 @@ RectTransform:
   - {fileID: 1459382205}
   - {fileID: 1948233962}
   m_Father: {fileID: 346867440}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -3.5872803, y: -13}
-  m_SizeDelta: {x: 1100, y: 900}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -61.6}
+  m_SizeDelta: {x: 0, y: -123.27222}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &749209460
 MonoBehaviour:
@@ -3300,7 +3300,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Content: {fileID: 1413559114}
-  m_Horizontal: 1
+  m_Horizontal: 0
   m_Vertical: 1
   m_MovementType: 1
   m_Elasticity: 0.1
@@ -3679,8 +3679,6 @@ MonoBehaviour:
   m_HumanSegmentationMenu: {fileID: 1468820548}
   m_PlaneDetectionMenu: {fileID: 881169046}
   m_MeshingMenu: {fileID: 2008080040}
-  m_SampleUX: {fileID: 0}
-  m_CheckSupport: {fileID: 0}
 --- !u!4 &774532499
 Transform:
   m_ObjectHideFlags: 0
@@ -7459,7 +7457,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000015258789, y: 0.00007243082}
+  m_AnchoredPosition: {x: 0.000015258789, y: -0.0002787175}
   m_SizeDelta: {x: 0, y: 1100}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &1416737520
@@ -7756,7 +7754,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1141134466}
   m_HandleRect: {fileID: 1141134465}
   m_Direction: 0
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -9929,7 +9927,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1130901185}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.80272734
+  m_Size: 0.9999984
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -10409,7 +10407,7 @@ RectTransform:
   - {fileID: 1742233075}
   - {fileID: 1536440841}
   m_Father: {fileID: 346867440}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}


### PR DESCRIPTION
Tooltip was behind the rest of the menu, and the menu wasn't set to stretch. This resulted in it being cut off on most phones and any landscape orientation.

Before:
![image](https://user-images.githubusercontent.com/2693840/84963501-d7b4e500-b109-11ea-84e6-6c28cae801bb.png)

After:
![image](https://user-images.githubusercontent.com/2693840/84963507-dc799900-b109-11ea-9e8e-244d7c6fef89.png)
