### PR TITLE
Avoid NullReferenceException in CheckAvailableFeatures in Editor

### DIFF
--- a/Assets/Scripts/UX/CheckAvailableFeatures.cs
+++ b/Assets/Scripts/UX/CheckAvailableFeatures.cs
@@ -224,7 +224,8 @@ namespace UnityEngine.XR.ARFoundation.Samples
         void Start()
         {
             var activeLoader = LoaderUtility.GetActiveLoader();
-
+            if(!activeLoader) return;
+            
             var planeDescriptors = new List<XRPlaneSubsystemDescriptor>();
             SubsystemManager.GetSubsystemDescriptors<XRPlaneSubsystemDescriptor>(planeDescriptors);
 


### PR DESCRIPTION
When pressing Play in Unity Editor, a nullref exception is thrown because activeLoader will be null. This PR fixes the nullreference exception and allows to at least see that no features are available in Editor without errors.

![image](https://user-images.githubusercontent.com/2693840/85317949-7ef59b80-b4bf-11ea-9512-7736c1b44678.png)
