### PR TITLE
Update manifest.json to include new Newtonsoft package dependency

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.inputsystem": "1.8.2",
     "com.unity.mathematics": "1.3.2",
     "com.unity.mobile.android-logcat": "1.4.1",
+    "com.unity.nuget.newtonsoft-json": "3.2.1",
     "com.unity.render-pipelines.universal": "17.0.3",
     "com.unity.ugui": "2.0.0",
     "com.unity.xr.arcore": "6.0.2",


### PR DESCRIPTION
The latest 6.0.2 AR foundation release and samples update added a dependency that did not get accounted for in the manifest for the samples package dependencies.  This change addresses that.
